### PR TITLE
jack4all

### DIFF
--- a/extras/Build/juce_build_tools/utils/juce_PlistOptions.cpp
+++ b/extras/Build/juce_build_tools/utils/juce_PlistOptions.cpp
@@ -292,45 +292,44 @@ namespace juce::build_tools
         plistKey.addTextElement ("AudioComponents");
 
         XmlElement plistEntry ("array");
-        auto* dict = plistEntry.createNewChildElement ("dict");
 
-        auto truncatedCode = pluginManufacturerCode.substring (0, 4);
-        auto pluginSubType = pluginCode.substring (0, 4);
+        const std::vector<juce::String> auTypes { "aumu", "aumf" };
+        const std::vector<juce::String> subTypes { "2kXa", "2kXL" };
 
-        if (truncatedCode.toLowerCase() == truncatedCode)
+        for (int i = 0; i < auTypes.size(); i++)
         {
-            throw SaveError ("AudioUnit plugin code identifiers invalid!\n\n"
-                             "You have used only lower case letters in your AU plugin manufacturer identifier. "
-                             "You must have at least one uppercase letter in your AU plugin manufacturer "
-                             "identifier code.");
-        }
+            const auto auType = auTypes[i];
+            const auto subType = subTypes[i];
 
-        addPlistDictionaryKey (*dict, "name", pluginManufacturer + ": " + pluginName);
-        addPlistDictionaryKey (*dict, "description", pluginDescription);
-        addPlistDictionaryKey (*dict, "factoryFunction", pluginAUExportPrefix + "Factory");
-        addPlistDictionaryKey (*dict, "manufacturer", truncatedCode);
-        addPlistDictionaryKey (*dict, "type", auMainType.removeCharacters ("'"));
-        addPlistDictionaryKey (*dict, "subtype", pluginSubType);
-        addPlistDictionaryKey (*dict, "version", getAUVersionAsHexInteger (*this));
+            auto* dict = plistEntry.createNewChildElement ("dict");
 
-        if (isAuSandboxSafe)
-        {
-            addPlistDictionaryKey (*dict, "sandboxSafe", true);
-        }
-        else if (! suppressResourceUsage)
-        {
-            dict->createNewChildElement ("key")->addTextElement ("resourceUsage");
-            auto* resourceUsageDict = dict->createNewChildElement ("dict");
+            addPlistDictionaryKey (*dict, "name", "Izmar: VMPC2000XL AUv2");
+            addPlistDictionaryKey (*dict, "description", pluginDescription);
+            addPlistDictionaryKey (*dict, "factoryFunction", pluginAUExportPrefix + "Factory");
+            addPlistDictionaryKey (*dict, "manufacturer", "Izmr");
+            addPlistDictionaryKey (*dict, "type", auType); 
+            addPlistDictionaryKey (*dict, "subtype", subType);
+            addPlistDictionaryKey (*dict, "version", getAUVersionAsHexInteger (*this));
 
-            addPlistDictionaryKey (*resourceUsageDict, "network.client", true);
-            addPlistDictionaryKey (*resourceUsageDict, "temporary-exception.files.all.read-write", true);
-        }
+            if (isAuSandboxSafe)
+            {
+                addPlistDictionaryKey (*dict, "sandboxSafe", true);
+            }
+            else if (! suppressResourceUsage)
+            {
+                dict->createNewChildElement ("key")->addTextElement ("resourceUsage");
+                auto* resourceUsageDict = dict->createNewChildElement ("dict");
 
-        if (isPluginARAEffect)
-        {
-            dict->createNewChildElement ("key")->addTextElement ("tags");
-            auto* tagsArray = dict->createNewChildElement ("array");
-            tagsArray->createNewChildElement ("string")->addTextElement ("ARA");
+                addPlistDictionaryKey (*resourceUsageDict, "network.client", true);
+                addPlistDictionaryKey (*resourceUsageDict, "temporary-exception.files.all.read-write", true);
+            }
+
+            if (isPluginARAEffect)
+            {
+                dict->createNewChildElement ("key")->addTextElement ("tags");
+                auto* tagsArray = dict->createNewChildElement ("array");
+                tagsArray->createNewChildElement ("string")->addTextElement ("ARA");
+            }
         }
 
         return { plistKey, plistEntry };
@@ -347,29 +346,36 @@ namespace juce::build_tools
         addPlistDictionaryKey (plistEntry, "NSExtensionPointIdentifier", "com.apple.AudioUnit-UI");
         plistEntry.createNewChildElement ("key")->addTextElement ("NSExtensionAttributes");
 
+        const std::vector<juce::String> auTypes { "aumu", "aumf" };
+        const std::vector<juce::String> subTypes { "2kXa", "2kXL" };
         auto* dict = plistEntry.createNewChildElement ("dict");
+
         dict->createNewChildElement ("key")->addTextElement ("AudioComponents");
         auto* componentArray = dict->createNewChildElement ("array");
 
-        auto* componentDict = componentArray->createNewChildElement ("dict");
 
-        addPlistDictionaryKey (*componentDict, "name", pluginManufacturer + ": " + pluginName);
-        addPlistDictionaryKey (*componentDict, "description", pluginDescription);
-        addPlistDictionaryKey (*componentDict, "factoryFunction", pluginAUExportPrefix + "FactoryAUv3");
-        addPlistDictionaryKey (*componentDict, "manufacturer", pluginManufacturerCode.substring (0, 4));
-        addPlistDictionaryKey (*componentDict, "type", auMainType.removeCharacters ("'"));
-        addPlistDictionaryKey (*componentDict, "subtype", pluginCode.substring (0, 4));
-        addPlistDictionaryKey (*componentDict, "version", getAUVersionAsHexInteger (*this));
-        addPlistDictionaryKey (*componentDict, "sandboxSafe", true);
+        for (int i = 0; i < auTypes.size(); i++)
+        {
+            const auto auType = auTypes[i];
+            const auto subType = subTypes[i];
 
-        componentDict->createNewChildElement ("key")->addTextElement ("tags");
-        auto* tagsArray = componentDict->createNewChildElement ("array");
+            auto* componentDict = componentArray->createNewChildElement ("dict");
 
-        tagsArray->createNewChildElement ("string")
-                 ->addTextElement (isPluginSynth ? "Synth" : "Effects");
+            addPlistDictionaryKey (*componentDict, "name", "Izmar: VMPC2000XL AUv3");
+            addPlistDictionaryKey (*componentDict, "description", pluginDescription);
+            addPlistDictionaryKey (*componentDict, "factoryFunction", pluginAUExportPrefix + "FactoryAUv3");
+            addPlistDictionaryKey (*componentDict, "manufacturer", "Izmr");
+            addPlistDictionaryKey (*componentDict, "type", auType);
+            addPlistDictionaryKey (*componentDict, "subtype", subType);
+            addPlistDictionaryKey (*componentDict, "version", getAUVersionAsHexInteger (*this));
+            addPlistDictionaryKey (*componentDict, "sandboxSafe", true);
 
-        if (auMainType.removeCharacters ("'") == "aumi")
-            tagsArray->createNewChildElement ("string")->addTextElement ("MIDI");
+            componentDict->createNewChildElement ("key")->addTextElement ("tags");
+            auto* tagsArray = componentDict->createNewChildElement ("array");
+
+            tagsArray->createNewChildElement ("string")
+                     ->addTextElement ("Sampler");
+        }
 
         return { plistKey, plistEntry };
     }

--- a/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp
@@ -94,7 +94,7 @@ void AudioIODeviceType::callDeviceChangeListeners()
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_ALSA()         { return nullptr; }
 #endif
 
-#if (JUCE_LINUX || JUCE_BSD) && JUCE_JACK
+#if (JUCE_LINUX || JUCE_BSD || JUCE_MAC || JUCE_WINDOWS) && JUCE_JACK
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_JACK()         { return new JackAudioIODeviceType(); }
 #else
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_JACK()         { return nullptr; }

--- a/modules/juce_audio_devices/juce_audio_devices.cpp
+++ b/modules/juce_audio_devices/juce_audio_devices.cpp
@@ -164,19 +164,6 @@
   #include "native/juce_ALSA_linux.cpp"
  #endif
 
- #if JUCE_JACK
-  /* Got an include error here? If so, you've either not got jack-audio-connection-kit
-     installed, or you've not got your paths set up correctly to find its header files.
-
-     The package you need to install to get JACK support is "libjack-dev".
-
-     If you don't have the jack-audio-connection-kit library and don't want to build
-     JUCE with low latency audio support, just set the JUCE_JACK flag to 0.
-  */
-  #include <jack/jack.h>
-  #include "native/juce_JackAudio_linux.cpp"
- #endif
-
  #if (JUCE_LINUX && JUCE_BELA)
   /* Got an include error here? If so, you've either not got the bela headers
      installed, or you've not got your paths set up correctly to find its header
@@ -242,6 +229,25 @@ namespace juce
   }
  #endif
 
+#endif
+
+#if (JUCE_LINUX || JUCE_BSD || JUCE_MAC || JUCE_WINDOWS) && JUCE_JACK
+ /* Got an include error here? If so, you've either not got jack-audio-connection-kit
+    installed, or you've not got your paths set up correctly to find its header files.
+
+    Linux: The package you need to install to get JACK support is libjack-dev.
+
+    macOS: The package you need to install to get JACK support is jack, which you can
+    install using Homebrew.
+
+    Windows: The package you need to install to get JACK support is available from the
+    JACK Audio website. Download and run the installer for Windows.
+
+    If you don't have the jack-audio-connection-kit library and don't want to build
+    JUCE with low latency audio support, just set the JUCE_JACK flag to 0.
+ */
+ #include <jack/jack.h>
+ #include "native/juce_JackAudio.cpp"
 #endif
 
 #if ! JUCE_SYSTEMAUDIOVOL_IMPLEMENTED

--- a/modules/juce_audio_devices/juce_audio_devices.h
+++ b/modules/juce_audio_devices/juce_audio_devices.h
@@ -110,7 +110,7 @@
 #endif
 
 /** Config: JUCE_JACK
-    Enables JACK audio devices (Linux only).
+    Enables JACK audio devices.
 */
 #ifndef JUCE_JACK
  #define JUCE_JACK 0

--- a/modules/juce_audio_devices/native/juce_Audio_ios.cpp
+++ b/modules/juce_audio_devices/native/juce_Audio_ios.cpp
@@ -245,6 +245,81 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (iOSAudioIODeviceType)
 };
 
+class SubstituteAudioUnit
+{
+public:
+    /* Returns true if the audio callback was called. False if a timeout occurred. */
+    bool waitForAudioCallback()
+    {
+        if (audioUnit != nullptr)
+        {
+            AudioComponentInstanceDispose (audioUnit);
+            audioUnit = nullptr;
+        }
+
+        AudioComponentDescription desc;
+        desc.componentType = kAudioUnitType_Output;
+        desc.componentSubType = kAudioUnitSubType_RemoteIO;
+        desc.componentManufacturer = kAudioUnitManufacturer_Apple;
+        desc.componentFlags = 0;
+        desc.componentFlagsMask = 0;
+
+        AudioComponent comp = AudioComponentFindNext (nullptr, &desc);
+        AudioComponentInstanceNew (comp, &audioUnit);
+
+        if (audioUnit == nullptr)
+            return false;
+
+        {
+            AURenderCallbackStruct inputProc;
+            inputProc.inputProc = audioUnitCallback;
+            inputProc.inputProcRefCon = this;
+            AudioUnitSetProperty (audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &inputProc, sizeof (inputProc));
+        }
+
+        {
+            AudioStreamBasicDescription format;
+            zerostruct (format);
+            format.mSampleRate = [AVAudioSession sharedInstance].sampleRate;
+            format.mFormatID = kAudioFormatLinearPCM;
+            format.mFormatFlags = kAudioFormatFlagIsFloat | kAudioFormatFlagIsNonInterleaved | kAudioFormatFlagsNativeEndian | kLinearPCMFormatFlagIsPacked;
+            format.mBitsPerChannel = 8 * sizeof (float);
+            format.mFramesPerPacket = 1;
+            format.mChannelsPerFrame = 2;
+            format.mBytesPerFrame = format.mBytesPerPacket = sizeof (float);
+
+            AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,  0, &format, sizeof (format));
+            AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &format, sizeof (format));
+        }
+
+        AudioUnitInitialize (audioUnit);
+        AudioOutputUnitStart (audioUnit);
+
+        const auto result = audioCallbackOccurred.wait (1000.0);
+
+        AudioComponentInstanceDispose (audioUnit);
+        audioUnit = nullptr;
+
+        return result;
+    }
+
+private:
+    static OSStatus audioUnitCallback (void* object,
+                                       AudioUnitRenderActionFlags*,
+                                       const AudioTimeStamp*,
+                                       UInt32,
+                                       UInt32,
+                                       AudioBufferList*)
+    {
+        static_cast<SubstituteAudioUnit*> (object)->audioCallbackOccurred.signal();
+
+        return noErr;
+    }
+
+    AudioUnit audioUnit{};
+    WaitableEvent audioCallbackOccurred;
+};
+
 //==============================================================================
 struct iOSAudioIODevice::Pimpl final : public AsyncUpdater
 {
@@ -285,11 +360,13 @@ struct iOSAudioIODevice::Pimpl final : public AsyncUpdater
         if (category == AVAudioSessionCategoryPlayAndRecord)
         {
             options |= AVAudioSessionCategoryOptionDefaultToSpeaker
-                     | AVAudioSessionCategoryOptionAllowBluetooth
                      | AVAudioSessionCategoryOptionAllowAirPlay;
 
             if (@available (iOS 10.0, *))
                 options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+            
+            if (@available (iOS 14.5, *))
+                options |= AVAudioSessionCategoryOptionOverrideMutedMicrophoneInterruption;
         }
 
         JUCE_NSERROR_CHECK ([[AVAudioSession sharedInstance] setCategory: category
@@ -301,6 +378,16 @@ struct iOSAudioIODevice::Pimpl final : public AsyncUpdater
     {
         JUCE_NSERROR_CHECK ([[AVAudioSession sharedInstance] setActive: enabled
                                                                  error: &error]);
+
+        if (@available (ios 18, *))
+        {
+            if (enabled)
+            {
+                SubstituteAudioUnit au;
+                [[maybe_unused]] const auto success = au.waitForAudioCallback();
+                jassert (success);
+            }
+        }
     }
 
     int getBufferSize (const double currentSampleRate)
@@ -310,34 +397,63 @@ struct iOSAudioIODevice::Pimpl final : public AsyncUpdater
 
     int tryBufferSize (const double currentSampleRate, const int newBufferSize)
     {
-        NSTimeInterval bufferDuration = currentSampleRate > 0 ? (NSTimeInterval) ((newBufferSize + 1) / currentSampleRate) : 0.0;
+        const auto extraOffset = std::invoke ([&]
+        {
+            // Older iOS versions (iOS 12) seem to require that the requested buffer size is a bit
+            // larger than the desired buffer size.
+            // This breaks on iOS 18, which needs the buffer duration to be as precise as possible.
+            if (@available (ios 18, *))
+                return 0;
+
+            return 1;
+        });
+
+        NSTimeInterval bufferDuration = currentSampleRate > 0 ? (NSTimeInterval) (newBufferSize + extraOffset) / currentSampleRate : 0.0;
 
         auto session = [AVAudioSession sharedInstance];
-        JUCE_NSERROR_CHECK ([session setPreferredIOBufferDuration: bufferDuration
-                                                            error: &error]);
+
+        // According to the apple docs, it's best to set preferred sample rates and block sizes
+        // while the device is inactive, and then to query the real values after activation.
+        // Unfortunately, on iOS 18.0, the real block size isn't immediately available after
+        // a call to setActive, so we also need to wait for the first audio callback.
+        // This will be slow!
+        // https://developer.apple.com/library/archive/qa/qa1631/_index.html
+        setAudioSessionActive (false);
+
+        JUCE_NSERROR_CHECK ([session setPreferredIOBufferDuration: bufferDuration error: &error]);
+
+        setAudioSessionActive (true);
 
         return getBufferSize (currentSampleRate);
     }
-
+    
     void updateAvailableBufferSizes()
     {
         availableBufferSizes.clear();
 
-        auto newBufferSize = tryBufferSize (sampleRate, 64);
-        jassert (newBufferSize > 0);
-
-        const auto longestBufferSize  = tryBufferSize (sampleRate, 4096);
-
-        while (newBufferSize <= longestBufferSize)
+        const auto [minBufSize, maxBufSize] = std::invoke ([this]
         {
-            availableBufferSizes.add (newBufferSize);
-            newBufferSize *= 2;
-        }
+            constexpr auto suggestedMin = 64;
+            constexpr auto suggestedMax = 4096;
+
+            if (@available (ios 18, *))
+                return std::tuple (suggestedMin, suggestedMax);
+
+            const auto min = tryBufferSize (sampleRate, suggestedMin);
+            const auto max = tryBufferSize (sampleRate, suggestedMax);
+
+            bufferSize = tryBufferSize (sampleRate, bufferSize);
+
+            return std::tuple (min, max);
+        });
+
+        jassert (minBufSize > 0);
+
+        for (auto i = minBufSize; i <= maxBufSize; i *= 2)
+            availableBufferSizes.add (i);
 
         // Sometimes the largest supported buffer size is not a power of 2
-        availableBufferSizes.addIfNotAlreadyThere (longestBufferSize);
-
-        bufferSize = tryBufferSize (sampleRate, bufferSize);
+        availableBufferSizes.addIfNotAlreadyThere (maxBufSize);
 
        #if JUCE_IOS_AUDIO_LOGGING
         {

--- a/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
+++ b/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
@@ -30,7 +30,11 @@ static void* juce_loadJackFunction (const char* const name)
     if (juce_libjackHandle == nullptr)
         return nullptr;
 
+   #if JUCE_WINDOWS
+    return GetProcAddress ((HMODULE) juce_libjackHandle, name);
+   #else
     return dlsym (juce_libjackHandle, name);
+   #endif
 }
 
 #define JUCE_DECL_JACK_FUNCTION(return_type, fn_name, argument_types, arguments)  \
@@ -592,8 +596,19 @@ public:
         inputNames.clear();
         outputNames.clear();
 
+       #if (JUCE_LINUX || JUCE_BSD)
         if (juce_libjackHandle == nullptr)  juce_libjackHandle = dlopen ("libjack.so.0", RTLD_LAZY);
         if (juce_libjackHandle == nullptr)  juce_libjackHandle = dlopen ("libjack.so",   RTLD_LAZY);
+       #elif JUCE_MAC
+        if (juce_libjackHandle == nullptr)  juce_libjackHandle = dlopen ("libjack.dylib", RTLD_LAZY);
+       #elif JUCE_WINDOWS
+        #if JUCE_64BIT
+         if (juce_libjackHandle == nullptr)  juce_libjackHandle = LoadLibraryA ("libjack64.dll");
+        #else
+         if (juce_libjackHandle == nullptr)  juce_libjackHandle = LoadLibraryA ("libjack.dll");
+        #endif
+       #endif
+
         if (juce_libjackHandle == nullptr)  return;
 
         jack_status_t status = {};

--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_AU_1.mm
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_AU_1.mm
@@ -116,8 +116,31 @@ public:
                            (UInt32) AudioUnitHelpers::getBusCountForWrapper (*juceFilter, true),
                            (UInt32) AudioUnitHelpers::getBusCountForWrapper (*juceFilter, false))
     {
-        inParameterChangedCallback = false;
+        std::function<std::string()> auComponentTypeFn = [component] {
+            const AudioComponent audioComponent = AudioComponentInstanceGetComponent(component);
+            AudioComponentDescription desc;
+            const OSStatus result = AudioComponentGetDescription(audioComponent, &desc);
+            
+            if (result == noErr)
+            {
+                const auto componentType = desc.componentType;
+                return std::string {
+                    static_cast<char>((componentType >> 24) & 0xFF),
+                    static_cast<char>((componentType >> 16) & 0xFF),
+                    static_cast<char>((componentType >> 8) & 0xFF),
+                    static_cast<char>(componentType & 0xFF)
+                };
+            }
+            else
+            {
+                return std::string("");
+            }
+        };
+        
+        juceFilter->auComponentType = auComponentTypeFn;
 
+        inParameterChangedCallback = false;
+                
        #ifdef JucePlugin_PreferredChannelConfigurations
         short configs[][2] = {JucePlugin_PreferredChannelConfigurations};
         const int numConfigs = sizeof (configs) / sizeof (short[2]);
@@ -355,6 +378,19 @@ public:
 
     UInt32 SupportedNumChannels (const AUChannelInfo** outInfo) override
     {
+        const auto isMusicDevice = GetComponentDescription().componentType == kAudioUnitType_MusicDevice;
+
+        if (isMusicDevice)
+        {
+            // See https://github.com/juce-framework/JUCE/issues/1508
+            // We only do this for the aumu (music device) case.
+            // The aumf (music effect) needs an actual implementation, or, in auval terminology,
+            // provide an "explicit" layout.
+            // I suspect we could alternatively pass different bus counts into the MusicDeviceBase
+            // constructor, but implementing SupportedNumChannels a bit differently is easier.
+            return 0;
+        }
+
         if (outInfo != nullptr)
             *outInfo = channelInfo.getRawDataPointer();
 
@@ -918,6 +954,7 @@ public:
         return sizeInBytes;
     }
 
+    /* Removed by Izmar. See https://github.com/juce-framework/JUCE/issues/1508
     std::vector<AudioChannelLayoutTag> GetChannelLayoutTags (AudioUnitScope inScope, AudioUnitElement inElement) override
     {
         const auto info = getElementInfo (inScope, inElement);
@@ -930,6 +967,7 @@ public:
 
         return getSupportedBusLayouts (info.isInput, info.busNr);
     }
+    */
 
     OSStatus SetAudioChannelLayout (AudioUnitScope scope, AudioUnitElement element, const AudioChannelLayout* inLayout) override
     {

--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_AUv3.mm
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_AUv3.mm
@@ -120,6 +120,17 @@ public:
         JUCE_END_IGNORE_WARNINGS_GCC_LIKE
           processorHolder (processor)
     {
+        std::function<std::string()> auComponentTypeFn = [this] {
+            const OSType componentType = getAudioUnit().componentDescription.componentType;
+            return std::string {
+                static_cast<char>((componentType >> 24) & 0xFF),
+                static_cast<char>((componentType >> 16) & 0xFF),
+                static_cast<char>((componentType >> 8) & 0xFF),
+                static_cast<char>(componentType & 0xFF)
+            };
+        };
+        
+        processor->get()->auComponentType = auComponentTypeFn;
         init();
     }
 
@@ -128,7 +139,6 @@ public:
           processorHolder (new AudioProcessorHolder (createPluginFilterOfType (AudioProcessor::wrapperType_AudioUnitv3)))
     {
         jassert (MessageManager::getInstance()->isThisTheMessageThread());
-        initialiseJuce_GUI();
 
         init();
     }
@@ -834,7 +844,46 @@ private:
             //==============================================================================
             addMethod (@selector (inputBusses),                             [] (id self, SEL)                                                   { return _this (self)->getInputBusses(); });
             addMethod (@selector (outputBusses),                            [] (id self, SEL)                                                   { return _this (self)->getOutputBusses(); });
-            addMethod (@selector (channelCapabilities),                     [] (id self, SEL)                                                   { return _this (self)->getChannelCapabilities(); });
+            addMethod (@selector (channelCapabilities),
+                                                                            [] (id self, SEL)
+                       {
+                /*
+                 * This implementation has been modified by Izmar. It yields the AUv3 equivalent of
+                 https://github.com/izzyreal/juce-vmpc-patches/blob/main/auv2_aumu_default_bus_layout_in_order_to_support_mixed_mono_and_stereo_outputs.patch
+                 * Also see https://github.com/juce-framework/JUCE/issues/1508
+                 *
+                 * To summarize, when VMPC2000XL runs as a music device (instrument), we don't explicitly publish
+                 * supported channel capabilities, which is accomplished by returning `AUAudioUnit`'s default
+                 * implementation.
+                 *
+                 * This results in auval reporting there's only a default implicit layout, and that happens to be
+                 * one that we're very interested in: 1x stereo in, 5x stereo out, and 8x mono out. Logic correctly
+                 * picks up on this layout, and also adds a 1x stereo in, 1x stereo out layout, which is also a good
+                 * option to have as a user.
+                 *
+                 * If we don't return the default implementation for instruments, Logic is not able to detect and
+                 * expose an instrument with a mix of stereo and mono buses. It even starts reporting an unsupported
+                 * and rather strange layout: 13x stereo out, which is far over the 18 mono channels that the
+                 * plugin's buses amount to.
+                 *
+                 * Moreover, we leave the effect implementation as is, because auval starts failing if no explicit
+                 * layouts are provided for effects with 1x stereo in, 5x stereo out and 8x mono out buses. The
+                 * default JUCE implementation of returning `_this(self)->getChannelCapabilities()` happens to
+                 * accomplish a sane layout for effects, even if we advertise so many buses: 1x stereo in, 1x stereo
+                 * out.
+                 */
+                const OSType componentType = [self componentDescription].componentType;
+                const bool isMusicDevice = (componentType == kAudioUnitType_MusicDevice);
+
+                if (isMusicDevice)
+                {
+                    using SuperMethod = NSArray<NSNumber*>* (*)(id, SEL);
+                    SuperMethod superMethod = (SuperMethod) class_getMethodImplementation([AUAudioUnit class], @selector(channelCapabilities));
+                    return superMethod(self, @selector(channelCapabilities));
+                }
+
+                return _this(self)->getChannelCapabilities();
+            });
             addMethod (@selector (shouldChangeToFormat:forBus:),            [] (id self, SEL, AVAudioFormat* format, AUAudioUnitBus* bus)       { return _this (self)->shouldChangeToFormat (format, bus) ? YES : NO; });
 
             //==============================================================================
@@ -1728,6 +1777,7 @@ private:
 
     using ObserverPtr = std::unique_ptr<std::remove_pointer_t<AUParameterObserverToken>, ObserverDestructor>;
 
+    ScopedJuceInitialiser_GUI guiScope;
     AUAudioUnit* au;
     AudioProcessorHolder::Ptr processorHolder;
 
@@ -1799,7 +1849,6 @@ public:
     JuceAUViewController (AUViewController<AUAudioUnitFactory>* p)
         : myself (p)
     {
-        initialiseJuce_GUI();
     }
 
     ~JuceAUViewController()
@@ -1829,16 +1878,10 @@ public:
                     JUCE_IOS_MAC_VIEW* view = [[[JUCE_IOS_MAC_VIEW alloc] initWithFrame: convertToCGRect (editor->getBounds())] autorelease];
                     [myself setView: view];
 
-                   #if JUCE_IOS
                     editor->setVisible (false);
-                   #else
-                    editor->setVisible (true);
-                   #endif
-
-                    detail::PluginUtilities::addToDesktop (*editor, view);
 
                    #if JUCE_IOS
-                    if (JUCE_IOS_MAC_VIEW* peerView = [[[myself view] subviews] objectAtIndex: 0])
+                    if (auto* peerView = getPeerView())
                         [peerView setContentMode: UIViewContentModeTop];
 
                     if (auto* peer = dynamic_cast<UIViewPeerControllerReceiver*> (editor->getPeer()))
@@ -1862,16 +1905,21 @@ public:
 
                     editor->setBounds (convertToRectInt ([[myself view] bounds]));
 
-                    if (JUCE_IOS_MAC_VIEW* peerView = [[[myself view] subviews] objectAtIndex: 0])
-                    {
-                       #if JUCE_IOS
-                        [peerView setNeedsDisplay];
-                       #else
-                        [peerView setNeedsDisplay: YES];
-                       #endif
-                    }
+                    repaintView();
                 }
             }
+        }
+    }
+
+    void repaintView()
+    {
+        if (auto* peerView = getPeerView())
+        {
+           #if JUCE_IOS
+            [peerView setNeedsDisplay];
+           #else
+            [peerView setNeedsDisplay: YES];
+           #endif
         }
     }
 
@@ -1882,18 +1930,35 @@ public:
                 processor->memoryWarningReceived();
     }
 
-    void viewDidAppear (bool)
+    void viewWillDisappear()
     {
-        if (processorHolder.get() != nullptr)
-            if (AudioProcessorEditor* editor = getAudioProcessor().getActiveEditor())
-                editor->setVisible (true);
+        if (processorHolder.get() == nullptr)
+            return;
+
+        if (auto* editor = getAudioProcessor().getActiveEditor())
+            editor->removeFromDesktop();
     }
 
-    void viewDidDisappear (bool)
+    void viewDidAppear()
     {
-        if (processorHolder.get() != nullptr)
-            if (AudioProcessorEditor* editor = getAudioProcessor().getActiveEditor())
-                editor->setVisible (false);
+        if (processorHolder.get() == nullptr)
+            return;
+
+        if (auto* editor = getAudioProcessor().getActiveEditor())
+        {
+            editor->setVisible (true);
+            detail::PluginUtilities::addToDesktop (*editor, [myself view]);
+            editor->setBounds (convertToRectInt ([[myself view] bounds]));
+        }
+    }
+
+    void viewDidDisappear()
+    {
+        if (processorHolder.get() == nullptr)
+            return;
+
+        if (auto* editor = getAudioProcessor().getActiveEditor())
+            editor->setVisible (false);
     }
 
     CGSize getPreferredContentSize() const
@@ -1921,6 +1986,15 @@ public:
     }
 
 private:
+    JUCE_IOS_MAC_VIEW* getPeerView() const
+    {
+        if (auto* editor = getAudioProcessor().getActiveEditor())
+            if (auto* peer = editor->getPeer())
+                return static_cast<JUCE_IOS_MAC_VIEW*> (peer->getNativeHandle());
+
+        return nullptr;
+    }
+
     template <typename Callback>
     static void waitForExecutionOnMainThread (Callback&& callback)
     {
@@ -1965,6 +2039,7 @@ private:
     };
 
     //==============================================================================
+    ScopedJuceInitialiser_GUI guiScope;
     AUViewController<AUAudioUnitFactory>* myself;
     LockedProcessorHolder processorHolder;
     Rectangle<int> preferredSize { 1, 1 };
@@ -1994,8 +2069,13 @@ private:
 
 - (void) didReceiveMemoryWarning { cpp->didReceiveMemoryWarning(); }
 #if JUCE_IOS
-- (void) viewDidAppear: (BOOL) animated { cpp->viewDidAppear (animated); [super viewDidAppear:animated]; }
-- (void) viewDidDisappear: (BOOL) animated { cpp->viewDidDisappear (animated); [super viewDidDisappear:animated]; }
+- (void) viewDidAppear:     (BOOL) animated { cpp->viewDidAppear();     [super viewDidAppear:animated]; }
+- (void) viewDidDisappear:  (BOOL) animated { cpp->viewDidDisappear();  [super viewDidDisappear:animated]; }
+- (void) viewWillDisappear: (BOOL) animated { cpp->viewWillDisappear(); [super viewWillDisappear:animated]; }
+#else
+- (void) viewDidAppear     { cpp->viewDidAppear();     [super viewDidAppear]; }
+- (void) viewDidDisappear  { cpp->viewDidDisappear();  [super viewDidDisappear]; }
+- (void) viewWillDisappear { cpp->viewWillDisappear(); [super viewWillDisappear]; }
 #endif
 @end
 

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.h
@@ -73,6 +73,8 @@ protected:
     }
 
 public:
+    std::function<std::string()> auComponentType = []{ return ""; };
+
     //==============================================================================
     enum ProcessingPrecision
     {


### PR DESCRIPTION
This will allow you to use the jack audio interface on both macOS and Windows :)

These changes have been merged in JUCE-8, but have been implemented and tested with plugdata and JUCE-7.
Should work for vmpc as well.

https://github.com/plugdata-team/plugdata/pull/2005


The downside with jack standalone is that JUCE doesn't properly support jack port handling:
https://github.com/juce-framework/JUCE/issues/333